### PR TITLE
IL-24552 Lowering the minimum version to allow our error to appear

### DIFF
--- a/manifest_unityclient.json
+++ b/manifest_unityclient.json
@@ -5,7 +5,7 @@
     "version": "1.80.6643",
     "manifest_version": 2,
     "offline_enabled": false,
-    "minimum_chrome_version": "56",
+    "minimum_chrome_version": "45",
     "kiosk_enabled": true,
     "description": "Imagine Language & Literacy® teaches language and literacy to students around the world through engaging, interactive instruction.",
     "app": {


### PR DESCRIPTION
In Meriden they never got to our browser incompatible error because Chrome wouldn't let us load based on the minimum version set in this manifest file.