### PR TITLE
Add URL Handlers to auto launch

### DIFF
--- a/manifest_unityclient.json
+++ b/manifest_unityclient.json
@@ -46,5 +46,37 @@
     },
     "externally_connectable": {
         "matches": ["*://localhost:*/*", "*://127.0.0.1:*/*", "*://*.imaginelearning.com/*"]
-    }
+    },
+    "url_handlers": {
+        "testapp.imaginelearning.com" : {
+            "matches": [
+                "*://testapp.imaginelearning.com/*"
+            ],
+            "title": "Open Imagine Learning"
+        },
+        "rcapp.imaginelearning.com" : {
+            "matches": [
+                "*://rcapp.imaginelearning.com/*"
+            ],
+            "title": "Open Imagine Learning"
+        },
+        "partnerapp.imaginelearning.com" : {
+            "matches": [
+                "*://partnerapp.imaginelearning.com/*"
+            ],
+            "title": "Open Imagine Learning"
+        },
+        "eapapp.imaginelearning.com" : {
+            "matches": [
+                "*://eapapp.imaginelearning.com/*"
+            ],
+            "title": "Open Imagine Learning"
+        },
+        "app.imaginelearning.com": {
+            "matches": [
+                "*://app.imaginelearning.com/*"
+            ],
+            "title": "Open Imagine Learning"
+        }
+    },
 }


### PR DESCRIPTION
We used this method in the old client, it allows us to auto launch the app if installed when using a Clever SSO link. Documentation: https://developer.chrome.com/apps/manifest/url_handlers