### PR TITLE
APP-7855 Remove Power Permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,6 @@
         "browser",
         "alarms",
         "storage",
-        "power",
         "system.network",
         "audioCapture",
         {"fileSystem":["write","directory","retainEntries"]}

--- a/manifest_espanol.json
+++ b/manifest_espanol.json
@@ -18,7 +18,6 @@
         "webview",
         "alarms",
         "storage",
-        "power",
         "system.network",
         "audioCapture",
         {"fileSystem":["write","directory","retainEntries"]}


### PR DESCRIPTION
This removes the power dependency which allows us to be automatically included in the Public Session mode of Chrome. I also removed it for English, but that shouldn’t be required since we already are exclusively included.