### PR TITLE
Updating URL handlers for chrome update

### DIFF
--- a/manifest_unityclient.json
+++ b/manifest_unityclient.json
@@ -49,21 +49,9 @@
         "matches": ["*://localhost:*/*", "*://127.0.0.1:*/*", "*://*.imaginelearning.com/*"]
     },
     "url_handlers": {
-        "testapp.imaginelearning.com" : {
-            "matches": [
-                "*://testapp.imaginelearning.com/*"
-            ],
-            "title": "Open Imagine Learning"
-        },
-        "rcapp.imaginelearning.com" : {
-            "matches": [
-                "*://rcapp.imaginelearning.com/*"
-            ],
-            "title": "Open Imagine Learning"
-        },
         "app.imaginelearning.com": {
             "matches": [
-                "*://app.imaginelearning.com/*"
+                "https://app.imaginelearning.com/*"
             ],
             "title": "Open Imagine Learning"
         }


### PR DESCRIPTION
This removes TEST and RC since we can't have more than 1 domain verified.

I tested this using a Clever student on the production environment and confirm the app still opens and login credentials are passed as expected. 